### PR TITLE
Pass tippecanoe option, and set default maxzoom 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,8 @@ jobs:
         uses: ./__test__
         with:
           file: ./__test__/point.geojson
+
+      - name: 'case 3 - with tippecanoe options'
+        uses: ./__test__
+        with:
+          tp_options: "-z20 --force --output-to-directory tiles --layer test-layer --drop-densest-as-needed --no-tile-compression ./__test__/point.geojson"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,7 @@ jobs:
       - name: 'case 3 - with tippecanoe options'
         uses: ./__test__
         with:
-          tp_options: "-z20 --force --output-to-directory docs/tiles --layer test-layer --drop-densest-as-needed --no-tile-compression ./__test__/point.geojson"
+          file: ./__test__/point.geojson
+          out_dir: docs/tiles
+          layer: test-layers
+          tippecanoe_options: "-z20"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,4 @@ jobs:
       - name: 'case 3 - with tippecanoe options'
         uses: ./__test__
         with:
-          tp_options: "-z20 --force --output-to-directory tiles --layer test-layer --drop-densest-as-needed --no-tile-compression ./__test__/point.geojson"
+          tp_options: "-z20 --force --output-to-directory docs/tiles --layer test-layer --drop-densest-as-needed --no-tile-compression ./__test__/point.geojson"

--- a/__test__/action.yml
+++ b/__test__/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: g-simplestyle-v1
 
-  tp_options:
+  tippecanoe_options:
     description: 'Specify tippecanoe options.'
     required: false
 
@@ -34,4 +34,4 @@ runs:
     - ${{ inputs.geolonia_access_token }}
     - ${{ inputs.out_dir }}
     - ${{ inputs.layer }}
-    - ${{ inputs.tp_options }}
+    - ${{ inputs.tippecanoe_options }}

--- a/__test__/action.yml
+++ b/__test__/action.yml
@@ -16,6 +16,15 @@ inputs:
     required: false
     default: ''
 
+  layer:
+    description: 'Specify layer name.'
+    required: false
+    default: g-simplestyle-v1
+
+  tp_options:
+    description: 'Specify tippecanoe options.'
+    required: false
+
 runs:
   using: docker
   image: '../Dockerfile'
@@ -24,3 +33,5 @@ runs:
     - ${{ inputs.file }}
     - ${{ inputs.geolonia_access_token }}
     - ${{ inputs.out_dir }}
+    - ${{ inputs.layer }}
+    - ${{ inputs.tp_options }}

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     required: false
     default: g-simplestyle-v1
 
+  tp_options:
+    description: 'Specify tippecanoe options.'
+    required: false
+
 runs:
   using: docker
   image: 'docker://ghcr.io/geolonia/geolonia-locations-action:main'
@@ -30,3 +34,4 @@ runs:
     - ${{ inputs.geolonia_access_token }}
     - ${{ inputs.out_dir }}
     - ${{ inputs.layer }}
+    - ${{ inputs.tp_options }}

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: g-simplestyle-v1
 
-  tp_options:
+  tippecanoe_options:
     description: 'Specify tippecanoe options.'
     required: false
 
@@ -34,4 +34,4 @@ runs:
     - ${{ inputs.geolonia_access_token }}
     - ${{ inputs.out_dir }}
     - ${{ inputs.layer }}
-    - ${{ inputs.tp_options }}
+    - ${{ inputs.tippecanoe_options }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,7 @@ LOWER_EXT=`echo $EXT | tr '[:upper:]' '[:lower:]'`
 GEOLONIA_ACCESS_TOKEN=$2
 OUT_DIR=$3
 LAYER_NAME=$4
+TP_OPTIONS=$5
 
 BASE_URL=""
 if [ $GITHUB_REPOSITORY ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,7 +39,7 @@ else
   if [ $TP_OPTIONS ]; then
     tippecanoe $TP_OPTIONS
   else
-    tippecanoe $TILE_MAXZOOM_OPTION \
+    tippecanoe -z18 \
       --force \
       --output-to-directory $TILES_OUT_DIR \
       --layer $LAYER_NAME \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ LOWER_EXT=`echo $EXT | tr '[:upper:]' '[:lower:]'`
 GEOLONIA_ACCESS_TOKEN=$2
 OUT_DIR=$3
 LAYER_NAME=$4
-TP_OPTIONS=$5
+TIPPECANOE_OPTIONS=$5
 
 BASE_URL=""
 if [ $GITHUB_REPOSITORY ]; then
@@ -36,9 +36,9 @@ else
   
   echo "Converting GeoJSON to MBTiles..."
 
-  if [ "$TP_OPTIONS" ]; then
+  if [ "$TIPPECANOE_OPTIONS" ]; then
 
-    eval "tippecanoe $TP_OPTIONS"
+    eval "tippecanoe $TIPPECANOE_OPTIONS --force --output-to-directory $TILES_OUT_DIR --layer $LAYER_NAME --no-tile-compression $FILE"
   else
   
     tippecanoe -z18 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,9 +36,11 @@ else
   
   echo "Converting GeoJSON to MBTiles..."
 
-  if [ $TP_OPTIONS ]; then
-    tippecanoe $TP_OPTIONS
+  if [ "$TP_OPTIONS" ]; then
+
+    eval "tippecanoe $TP_OPTIONS"
   else
+  
     tippecanoe -z18 \
       --force \
       --output-to-directory $TILES_OUT_DIR \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,13 @@ else
 
   if [ "$TIPPECANOE_OPTIONS" ]; then
 
-    eval "tippecanoe $TIPPECANOE_OPTIONS --force --output-to-directory $TILES_OUT_DIR --layer $LAYER_NAME --no-tile-compression $FILE"
+    tippecanoe $TIPPECANOE_OPTIONS \
+      --force \
+      --output-to-directory $TILES_OUT_DIR \
+      --layer $LAYER_NAME \
+      --no-tile-compression \
+      $FILE
+      
   else
   
     tippecanoe -z18 \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,26 +33,20 @@ fi
 if [ $GEOLONIA_ACCESS_TOKEN ]; then
   GEOLONIA_ACCESS_TOKEN=$GEOLONIA_ACCESS_TOKEN geolonia upload-locations $1
 else
+  
+  echo "Converting GeoJSON to MBTiles..."
 
-  TILE_MAXZOOM_OPTION=""
-
-  # if geojson has one feature and geometry type is Point, set maxzoom to 14
-
-  if [ $(cat $FILE | jq '.features | length') -eq 1 ]; then
-    if [ $(cat $FILE | jq '.features[0].geometry.type') = '"Point"' ]; then
-      TILE_MAXZOOM_OPTION="-z14"
-      else
-      TILE_MAXZOOM_OPTION="-zg"
-    fi
+  if [ $TP_OPTIONS ]; then
+    tippecanoe $TP_OPTIONS
+  else
+    tippecanoe $TILE_MAXZOOM_OPTION \
+      --force \
+      --output-to-directory $TILES_OUT_DIR \
+      --layer $LAYER_NAME \
+      --drop-densest-as-needed \
+      --no-tile-compression \
+      $FILE
   fi
-
-  tippecanoe $TILE_MAXZOOM_OPTION \
-    --force \
-    --output-to-directory $TILES_OUT_DIR \
-    --layer $LAYER_NAME \
-    --drop-densest-as-needed \
-    --no-tile-compression \
-    $FILE
 
   find $TILES_OUT_DIR -name "*.pbf" -exec sh -c 'mv "$1" "${1%.pbf}".mvt' - '{}' \;
 


### PR DESCRIPTION
Close #18 #24 

- デフォルト maxzoom を z18 に設定する
- tippecanoe オプションが指定されていると、デフォルトのオプションを無視して、指定されたオプションを渡す

tippecanoe のオプション名を、`tp_options` にしたのですが、もっとこっちの方が良いなどあれば教えて頂けるとありがたいです。