### PR TITLE
Fix script copy path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ RUN npm install -g csv2geojson
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod 744 /entrypoint.sh
 
-COPY bin/convertToNumber.js /bin/convertToNumber.js
+COPY bin/convertToNumber.js /convertToNumber.js
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,7 +31,7 @@ if [ "$LOWER_EXT" = "csv" ]; then
 fi
 
 # convert coordinates value type string to number
-node ./bin/convertToNumber.js $FILE
+node /convertToNumber.js $FILE
 
 if [ $GEOLONIA_ACCESS_TOKEN ]; then
   GEOLONIA_ACCESS_TOKEN=$GEOLONIA_ACCESS_TOKEN geolonia upload-locations $1


### PR DESCRIPTION
vector-tiles-api で以下のようなエラーが出たため、ファイルのコピー先を修正しました。

https://github.com/naogify/test-api/actions/runs/3475786524/jobs/5810381388
```
internal/modules/cjs/loader.js:818
  throw err;
  ^

Error: Cannot find module '/github/workspace/bin/convertToNumber.js'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.Module._load (internal/modules/cjs/loader.js:667:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:[12](https://github.com/naogify/test-api/actions/runs/3475786524/jobs/5810381388#step:4:13))
    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```
