### PR TITLE
Add layer/tippecanoe_options description to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
           file: ./test/data.geojson           # [Required] Data source
           out_dir: ./docs                     # [Optional] Parent directory where tiles are generated as `<out_dir>/tiles`
           geolonia_access_token: 0a1b2c3d4e5f # [Optional] If specified, out_dir is ignored and Geolonia Locations is used. Otherwise, out_dir is respected and deployed to GitHub Pages
-          layer:                              # [Optional] Layer name, default value is g-simplestyle-v1
+          layer: sample-layer                 # [Optional] Layer name, default value is g-simplestyle-v1
           tippecanoe_options: -z 20 -Z4       # [Optional] If specified, default tippecanoe options except --force, --output-to-directory, --layer, --no-tile-compression are ignored.
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ jobs:
           file: ./test/data.geojson           # [Required] Data source
           out_dir: ./docs                     # [Optional] Parent directory where tiles are generated as `<out_dir>/tiles`
           geolonia_access_token: 0a1b2c3d4e5f # [Optional] If specified, out_dir is ignored and Geolonia Locations is used. Otherwise, out_dir is respected and deployed to GitHub Pages
+          layer:                              # [Optional] Layer name, default value is g-simplestyle-v1
+          tippecanoe_options: -z 20 -Z4       # [Optional] If specified, default tippecanoe options except --force, --output-to-directory, --layer, --no-tile-compression are ignored.
 ```
 
 You can get Geolonia Access Token at https://app.geolonia.com/#/team/general.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jobs:
           out_dir: ./docs                     # [Optional] Parent directory where tiles are generated as `<out_dir>/tiles`
           geolonia_access_token: 0a1b2c3d4e5f # [Optional] If specified, out_dir is ignored and Geolonia Locations is used. Otherwise, out_dir is respected and deployed to GitHub Pages
           layer: sample-layer                 # [Optional] Layer name, default value is g-simplestyle-v1
-          tippecanoe_options: -z 20 -Z4       # [Optional] If specified, default tippecanoe options except --force, --output-to-directory, --layer, --no-tile-compression are ignored.
+          tippecanoe_options: -z 20 -Z4       # [Optional] If specified, default tippecanoe options without --force, --output-to-directory, --layer, --no-tile-compression are ignored.
 ```
 
 You can get Geolonia Access Token at https://app.geolonia.com/#/team/general.


### PR DESCRIPTION
`layer` と `tippecanoe_options` についての説明を README に追加しました。